### PR TITLE
Fix ignoring errors on Windows CI

### DIFF
--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -18,6 +18,6 @@ for /r "." %%a in (build\bin\*_mpi.exe) do (
     echo %%~na
     echo -------------------------------------
     for /l %%x in (1, 1, 10) do (
-        mpiexec -np 4 %%~fa
+        mpiexec -np 4 %%~fa || exit /b 1
     )
 )


### PR DESCRIPTION
Actually I just added checking for return code of mpiexec.
Now it fails when we have some error in tests. Proof: https://ci.appveyor.com/project/gooddoog/pp-2019-autumn/builds/27668651/job/nsy9sm7x95xiso0n